### PR TITLE
Add Next.js migration guides

### DIFF
--- a/boot-up.md
+++ b/boot-up.md
@@ -1,0 +1,61 @@
+# Next.js Project Initialization Steps
+
+This repository currently contains a PHP application. To migrate to Next.js with TypeScript, start by creating a new Next.js project alongside this code base (or in a separate directory).
+
+## 1. Prepare the environment
+
+1. Install **Node.js** (version 18 or later is recommended). You can use `nvm` to manage Node versions:
+   ```bash
+   nvm install 18
+   nvm use 18
+   ```
+2. Ensure **npm** (or **yarn** if preferred) is available. Update to the latest version:
+   ```bash
+   npm install -g npm
+   ```
+
+## 2. Create a Next.js application
+
+1. From the command line, run the Next.js project generator with TypeScript support:
+   ```bash
+   npx create-next-app@latest next-indexhibit --typescript
+   cd next-indexhibit
+   ```
+   This will scaffold a basic project in the `next-indexhibit` folder.
+2. Initialize a git repository in the new project if desired and commit the generated files.
+
+## 3. Install additional packages
+
+Inside the newly created project directory, install dependencies used during the migration:
+
+```bash
+npm install next react react-dom
+npm install --save-dev typescript @types/react @types/node @types/react-dom
+
+# Styling (example: Tailwind CSS)
+npm install -D tailwindcss postcss autoprefixer
+npx tailwindcss init -p
+
+# Database (example: Prisma with MySQL)
+npm install prisma @prisma/client
+npx prisma init
+
+# Authentication (example: next-auth)
+npm install next-auth
+
+# Image manipulation for uploads
+npm install sharp
+```
+
+Adjust the list of packages as you refine the project requirements (for example, you may need libraries for file uploads, form handling, or state management).
+
+## 4. Development tasks
+
+1. Start the development server to verify the new setup:
+   ```bash
+   npm run dev
+   ```
+2. Open `http://localhost:3000` in your browser to see the default Next.js page.
+3. Commit the baseline project so subsequent migration work has a stable starting point.
+
+**Next steps**: follow the migration plan outlined in `the-plan.md` to port functionality from the existing PHP code into the new Next.js TypeScript project.

--- a/the-plan.md
+++ b/the-plan.md
@@ -1,0 +1,60 @@
+# Migration Plan: PHP to Next.js (TypeScript)
+
+This document outlines tasks required to migrate the existing PHP-based Indexhibit project to a modern Next.js application written in TypeScript.
+
+---
+
+## 1. Analyze the current PHP codebase
+
+1. Examine entry points such as `index.php` to understand how configuration, routing, and plugins are loaded. For example, the current root script loads configuration files and initializes hooks:
+   ```php
+   if (file_exists('ndxzsite/config/config.php')) require_once 'ndxzsite/config/config.php';
+   require_once 'ndxzsite/config/options.php';
+   require_once 'ndxzstudio/defaults.php';
+   require_once 'ndxzstudio/common.php';
+   $OBJ =& load_class('core', true, 'lib');
+   $OBJ->assign_core_front();
+   ```
+2. Review templates such as `ndxzsite/default/index.php` to map how pages are composed. These templates use custom tags (`<last:...>` and `<plugin:...>`) that will need React/Next.js equivalents.
+3. Inspect the installation script (`ndxzstudio/install.php`) to determine the database schema—tables like `objects`, `media`, `sections`, `settings`, and `plugins` are created here.
+4. Catalog existing assets (images, CSS, JavaScript) under `ndxzsite` and `ndxzstudio/asset` for migration into the Next.js project.
+
+## 2. Plan the new Next.js architecture
+
+1. **TypeScript**: the project will be written entirely in TypeScript for type safety.
+2. **Routing**: use Next.js file-based routing to replace PHP routes. Dynamic routes will mirror how `index.php` resolves content based on URL parameters.
+3. **API routes**: create Next.js API endpoints for data operations (CRUD for exhibits, media, users, etc.). These will replace the various PHP modules found in `ndxzstudio/module`.
+4. **Database layer**: migrate the MySQL schema defined in `ndxzstudio/install.php` to an ORM such as Prisma. Re‑create tables including `objects`, `media`, `sections`, `settings`, and `users`.
+5. **Authentication**: implement a modern auth solution (e.g., `next-auth`) to handle login for the admin dashboard.
+6. **Admin dashboard**: re‑create the functionality of `ndxzstudio` as protected routes/pages in Next.js. Each module (exhibits, system settings, user management, statistics, etc.) becomes a React component or page under `/admin`.
+7. **Front‑end rendering**: convert templates from `ndxzsite/default` and any other themes into React components. Replace `<last:...>` and `<plugin:...>` tags with appropriate React logic or custom components.
+8. **File uploads & media**: use Next.js API routes combined with a library like `multer` or `next-cloudinary` to upload files. Store metadata in the `media` table and files under `/public` or an external storage service.
+9. **Plugin system**: replicate the hook mechanism (see `ndxzstudio/lib/hook.php`) with a plugin architecture in Node/Next.js—possibly using dynamic imports and a registry of available hooks.
+10. **Internationalization**: port translation files from `ndxzstudio/lang` into Next.js using its built‑in `i18n` support or a library like `next-i18next`.
+11. **Caching & performance**: evaluate features like caching flags in `options.php` and replicate them using Next.js middleware or incremental static regeneration.
+12. **Testing**: set up unit and integration tests (Jest, React Testing Library) to verify components and API routes.
+
+## 3. Step‑by‑step migration tasks
+
+1. **Initialize** the Next.js project (see `boot-up.md`).
+2. **Replicate the database schema** using Prisma models based on the `install.php` definitions.
+3. **Implement authentication** and create protected admin routes.
+4. **Build admin modules**:
+   - Exhibits management (CRUD for pages and media).
+   - System settings, sections, and user management.
+   - Statistics views if desired.
+5. **Convert front-end templates** to React components, starting with the default theme.
+6. **Implement dynamic routing** so URLs generated in PHP (for sections, exhibits, tags) resolve via Next.js pages.
+7. **Migrate assets** (images, CSS, JS) into the `/public` folder or appropriate static directories.
+8. **Develop a plugin framework** in Node that mimics the existing hook system, allowing custom code to inject behavior.
+9. **Provide API endpoints** for features currently handled by PHP scripts (such as image processing or AJAX requests found in the PHP modules).
+10. **Verify feature parity** with the PHP site by comparing output and behavior for each section.
+11. **Deploy** the Next.js application and perform final data migration from the old MySQL database.
+
+## 4. Post‑migration cleanup
+
+- Remove unused PHP files once the Next.js version is stable.
+- Document how to develop plugins or themes within the new architecture.
+- Monitor performance and iterate on caching or optimization strategies.
+
+Following this plan should result in a fully TypeScript-based Next.js application that replicates the functionality of the original Indexhibit PHP site while benefiting from modern tooling and improved maintainability.


### PR DESCRIPTION
## Summary
- add `boot-up.md` outlining how to start a Next.js/TypeScript project
- add `the-plan.md` describing step-by-step migration from PHP to Next.js

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683bed183ed0832da44e5dd3dda02920